### PR TITLE
Get the test working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,8 @@ $(TF_VARS): azure-test.pub
 	  && ../terraform plan \
 	  && ../terraform apply -auto-approve
 	# we need to ignore errors between here and the destroy, so make commands start with a minus
-	terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' > mgmt_ip.txt
-	echo -n "Host mgmt\n\tIdentityFile azure-test\n\tHostname " > ssh-config
-	cat mgmt_ip.txt >> ssh-config
+	echo -n "Host mgmt\n\tIdentityFile azure-test\n\tCheckHostIP no\n\tHostname " > ssh-config
+	terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' >> ssh-config
 	-cat ssh-config
 	-ssh -F ssh-config opc@mgmt  "while [ ! -f /mnt/shared/finalised/mgmt ] ; do sleep 2; done" ## wait for ansible
 	-ssh -F ssh-config opc@mgmt  "echo -ne 'VM.Standard2.1:\n  1: 1\n  2: 1\n  3: 1\n' > limits.yaml && ./finish"

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ $(TF_VARS): azure-test.pub
 	sed -i -e "/compartment_ocid/ s/ocid1.compartment.oc1.../$(COMPARTMENT_OCID)/" $(TF_VARS)
 	sed -i -e "/ssh_public_key/ r azure-test.pub" $(TF_VARS)
 	sed -i -e "/FilesystemAD/ s/1/2/" $(TF_VARS)
+	sed -i -e "/ManagementShape/ s/VM.Standard1\.1/VM.Standard2.1/" $(TF_VARS)
 	cat  $(TF_VARS)
 	cd oci-cluster-terraform \
 	  && ../terraform init \

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,7 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
 	-sleep 10  # Make sure that the filesystem has synchronised
 	-scp -F ssh-config opc@mgmt:expected .
-	-ssh -F ssh-config opc@mgmt "ls"  # dbg
-	-scp -F ssh-config opc@mgmt:slurm-2.out .
+	-scp -F ssh-config opc@mgmt:/mnt/shared/test/slurm-2.out .
 	cd oci-cluster-terraform \
 	  && ../terraform destroy -auto-approve
 	diff -u slurm-2.out expected

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,9 @@ $(TF_VARS): azure-test.pub
 	  && ../terraform plan \
 	  && ../terraform apply -auto-approve
 	# we need to ignore errors between here and the destroy, so make commands start with a minus
-	echo MGMT_IP=$(shell terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep '^ManagementPublicIP' | awk '{print $$3}')
-	$(eval MGMT_IP=$(shell terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}'))
-	echo "Host mgmt\n\tIdentityFile azure-test\n\tHostname $(terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}')\n"  
-	echo "Host mgmt\n\tIdentityFile azure-test\n\tHostname $(shell terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}')\n"  
-	echo "Host mgmt\n\tIdentityFile azure-test\n\tHostname $(shell terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}')\n" > ssh-config
+	terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' > mgmt_ip.txt
+	echo -n "Host mgmt\n\tIdentityFile azure-test\n\tHostname " > ssh-config
+	cat mgmt_ip.txt >> ssh-config
 	-cat ssh-config
 	-ssh -F ssh-config opc@mgmt  "while [ ! -f /mnt/shared/finalised/mgmt ] ; do sleep 2; done" ## wait for ansible
 	-ssh -F ssh-config opc@mgmt  "echo -ne 'VM.Standard2.1:\n  1: 1\n  2: 1\n  3: 1\n' > limits.yaml && ./finish"

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ $(TF_VARS): azure-test.pub
 	-terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' >> ssh-config
 	-cat ssh-config
 	-ls -l
+	-mkdir --mode=700 ~/.ssh
 	-ls -l ~/.ssh
 	-ssh -F ssh-config opc@mgmt  "while [ ! -f /mnt/shared/finalised/mgmt ] ; do sleep 2; done" ## wait for ansible
 	-ssh -F ssh-config opc@mgmt  "echo -ne 'VM.Standard2.1:\n  1: 1\n  2: 1\n  3: 1\n' > limits.yaml && ./finish"

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ $(TF_VARS): azure-test.pub
 	sed -i -e "/FilesystemAD/ s/1/2/" $(TF_VARS)
 	cat  $(TF_VARS)
 	cd oci-cluster-terraform \
-	  && terraform init \
-	  && terraform validate \
-	  && terraform plan \
-	  && terraform apply -auto-approve
+	  && ../terraform init \
+	  && ../terraform validate \
+	  && ../terraform plan \
+	  && ../terraform apply -auto-approve
 	# we need to ignore errors between here and the destroy, so make commands start with a minus
 	echo MGMT_IP=$(shell terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep '^ManagementPublicIP' | awk '{print $$3}')
 	$(eval MGMT_IP=$(shell terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}'))
@@ -46,4 +46,4 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
 	-ssh -F ssh-config opc@mgmt "diff /mnt/shared/test/slurm-2.out expected" 
 	cd oci-cluster-terraform \
-	  && terraform destroy -auto-approve
+	  && ../terraform destroy -auto-approve

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(TF_VARS): azure-test.pub
 	  && ../terraform plan \
 	  && ../terraform apply -auto-approve
 	# we need to ignore errors between here and the destroy, so make commands start with a minus
-	echo -n "Host mgmt\n\tIdentityFile azure-test\n\tCheckHostIP no\n\tHostname " > ssh-config
+	echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking no\n\tHostname " > ssh-config
 	terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' >> ssh-config
 	-cat ssh-config
 	-ssh -F ssh-config opc@mgmt  "while [ ! -f /mnt/shared/finalised/mgmt ] ; do sleep 2; done" ## wait for ansible

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(TF_VARS): azure-test.pub
 	  && ../terraform plan \
 	  && ../terraform apply -auto-approve
 	# we need to ignore errors between here and the destroy, so make commands start with a minus
-	-echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking yes\n\tCheckHostIP no\n\tHostname " > ssh-config
+	-echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking no\n\tCheckHostIP no\n\tHostname " > ssh-config
 	-terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' >> ssh-config
 	-cat ssh-config
 	-ssh -F ssh-config opc@mgmt  "while [ ! -f /mnt/shared/finalised/mgmt ] ; do sleep 2; done" ## wait for ansible

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ azure-test.pub:
 
 $(TF_VARS): azure-test.pub
 	echo ${MY_MAPPED_ENV_VAR}
+	echo ${MY_MAPPED_ENV_VAR} | base64 --decode > oci_api_key.pem
 	ls -l
 	cat oci_api_key.pem
 	openssl rsa -pubout -outform DER -in oci_api_key.pem | openssl md5 -c

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt  'echo -ne "#!/bin/bash\n\nsrun hostname\n" > test.slm'
 	-ssh -F ssh-config opc@mgmt "echo vm-standard2-1-ad1-0001 > expected" 
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
+	-scp -F ssh-config opc@mgmt:expected .
+	-scp -F ssh-config opc@mgmt:slurm-2.out .
 	cd oci-cluster-terraform \
 	  && ../terraform destroy -auto-approve
-	scp -F ssh-config opc@mgmt:expected .
-	scp -F ssh-config opc@mgmt:slurm-2.out .
 	diff -u slurm-2.out expected

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt  "echo -ne 'VM.Standard2.1:\n  1: 1\n  2: 1\n  3: 1\n' > limits.yaml && ./finish"
 	-ssh -F ssh-config opc@mgmt  "sudo mkdir -p /mnt/shared/test && sudo chown opc /mnt/shared/test"
 	-ssh -F ssh-config opc@mgmt  'echo -ne "#!/bin/bash\n\nsrun hostname\n" > test.slm'
-	-ssh -F ssh-config opc@mgmt "echo vm-standard2-1-ad1-0001 > expected" 
+	-ssh -F ssh-config opc@mgmt "sacct -j 2 --format=NodeList --noheader | tr -d '[:space:]' > expected"  # Get the node the job ran on
+	-ssh -F ssh-config opc@mgmt "echo >> expected"  # Add newline to end
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
 	-sleep 5  # Make sure that the filesystem has synchronised
 	-scp -F ssh-config opc@mgmt:expected .

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt  'echo -ne "#!/bin/bash\n\nsrun hostname\n" > test.slm'
 	-ssh -F ssh-config opc@mgmt "echo vm-standard2-1-ad1-0001 > expected" 
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
-	-sleep 10  # Make sure that the filesystem has synchronised
+	-sleep 5  # Make sure that the filesystem has synchronised
 	-scp -F ssh-config opc@mgmt:expected .
 	-scp -F ssh-config opc@mgmt:/mnt/shared/test/slurm-2.out .
 	cd oci-cluster-terraform \

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,9 @@ $(TF_VARS): azure-test.pub
 	# we need to ignore errors between here and the destroy, so make commands start with a minus
 	echo MGMT_IP=$(shell terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep '^ManagementPublicIP' | awk '{print $$3}')
 	$(eval MGMT_IP=$(shell terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}'))
-	echo "Host mgmt\n\tIdentityFile azure-test\n\tHostname $(MGMT_IP)\n"  
-	echo "Host mgmt\n\tIdentityFile azure-test\n\tHostname $(MGMT_IP)\n" > ssh-config
+	echo "Host mgmt\n\tIdentityFile azure-test\n\tHostname $(terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}')\n"  
+	echo "Host mgmt\n\tIdentityFile azure-test\n\tHostname $(shell terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}')\n"  
+	echo "Host mgmt\n\tIdentityFile azure-test\n\tHostname $(shell terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}')\n" > ssh-config
 	-cat ssh-config
 	-ssh -F ssh-config opc@mgmt  "while [ ! -f /mnt/shared/finalised/mgmt ] ; do sleep 2; done" ## wait for ansible
 	-ssh -F ssh-config opc@mgmt  "echo -ne 'VM.Standard2.1:\n  1: 1\n  2: 1\n  3: 1\n' > limits.yaml && ./finish"

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt  'echo -ne "#!/bin/bash\n\nsrun hostname\n" > test.slm'
 	-ssh -F ssh-config opc@mgmt "echo vm-standard2-1-ad1-0001 > expected" 
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
-	-scp -F ssh-config opc@mgmt:expected .
 	-sleep 10  # Make sure that the filesystem has synchronised
-	-ls  # dbg
+	-scp -F ssh-config opc@mgmt:expected .
+	-ssh -F ssh-config opc@mgmt "ls"  # dbg
 	-scp -F ssh-config opc@mgmt:slurm-2.out .
 	cd oci-cluster-terraform \
 	  && ../terraform destroy -auto-approve

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,7 @@ $(TF_VARS): azure-test.pub
 	-echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking no\n\tCheckHostIP no\n\tHostname " > ssh-config
 	-terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' >> ssh-config
 	-cat ssh-config
-	-ls -l
 	-mkdir --mode=700 ~/.ssh
-	-ls -l ~/.ssh
 	-ssh -F ssh-config opc@mgmt  "while [ ! -f /mnt/shared/finalised/mgmt ] ; do sleep 2; done" ## wait for ansible
 	-ssh -F ssh-config opc@mgmt  "echo -ne 'VM.Standard2.1:\n  1: 1\n  2: 1\n  3: 1\n' > limits.yaml && ./finish"
 	-ssh -F ssh-config opc@mgmt  "sudo mkdir -p /mnt/shared/test && sudo chown opc /mnt/shared/test"
@@ -48,7 +46,7 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
 	-scp -F ssh-config opc@mgmt:expected .
 	-sleep 10  # Make sure that the filesystem has synchronised
-	-ls
+	-ls  # dbg
 	-scp -F ssh-config opc@mgmt:slurm-2.out .
 	cd oci-cluster-terraform \
 	  && ../terraform destroy -auto-approve

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt  "echo -ne 'VM.Standard2.1:\n  1: 1\n  2: 1\n  3: 1\n' > limits.yaml && ./finish"
 	-ssh -F ssh-config opc@mgmt  "sudo mkdir -p /mnt/shared/test && sudo chown opc /mnt/shared/test"
 	-ssh -F ssh-config opc@mgmt  'echo -ne "#!/bin/bash\n\nsrun hostname\n" > test.slm'
-	-ssh -F ssh-config opc@mgmt "sacct -j 2 --format=NodeList --noheader | tr -d ' ' > expected"  # Get the node the job ran on
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
+	-ssh -F ssh-config opc@mgmt "sacct -j 2 --format=NodeList --noheader | tr -d ' ' > expected"  # Get the node the job ran on
 	-sleep 5  # Make sure that the filesystem has synchronised
 	-scp -F ssh-config opc@mgmt:expected .
 	-scp -F ssh-config opc@mgmt:/mnt/shared/test/slurm-2.out .

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ azure-test.pub:
 	ssh-keygen -N ""  -f azure-test
 
 $(TF_VARS): azure-test.pub
+	ls -l
+	cat oci_api_key.pem
 	openssl rsa -pubout -outform DER -in oci_api_key.pem | openssl md5 -c
 	git clone https://github.com/ACRC/oci-cluster-terraform.git
 	cp $(TF_VARS).example $(TF_VARS)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(TF_VARS): azure-test.pub
 	  && ../terraform plan \
 	  && ../terraform apply -auto-approve
 	# we need to ignore errors between here and the destroy, so make commands start with a minus
-	-echo -n "Host mgmt\n\tIdentityFile azure-test\n\tHostname " > ssh-config
+	-echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking no\n\tHostname " > ssh-config
 	-terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' >> ssh-config
 	-cat ssh-config
 	-mkdir --mode=700 ~/.ssh

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ azure-test.pub:
 	ssh-keygen -N ""  -f azure-test
 
 $(TF_VARS): azure-test.pub
-	cat oci_api_key.pem
+	openssl rsa -pubout -outform DER -in oci_api_key.pem | openssl md5 -c
 	git clone https://github.com/ACRC/oci-cluster-terraform.git
 	cp $(TF_VARS).example $(TF_VARS)
 	sed -i -e '/private_key_path/ s/\/home\/user\/.oci/../' $(TF_VARS)

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt  "sudo mkdir -p /mnt/shared/test && sudo chown opc /mnt/shared/test"
 	-ssh -F ssh-config opc@mgmt  'echo -ne "#!/bin/bash\n\nsrun hostname\n" > test.slm'
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
-	-ssh -F ssh-config opc@mgmt "sacct -j 2 --format=NodeList --noheader | tr -d ' ' > expected"  # Get the node the job ran on
+	-ssh -F ssh-config opc@mgmt "sacct -j 2 --format=NodeList%-100 -X --noheader | tr -d ' ' > expected"  # Get the node the job ran on
 	-sleep 5  # Make sure that the filesystem has synchronised
 	-scp -F ssh-config opc@mgmt:expected .
 	-scp -F ssh-config opc@mgmt:/mnt/shared/test/slurm-2.out .

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ azure-test.pub:
 	ssh-keygen -N ""  -f azure-test
 
 $(TF_VARS): azure-test.pub
+	echo ${MY_MAPPED_ENV_VAR}
 	ls -l
 	cat oci_api_key.pem
 	openssl rsa -pubout -outform DER -in oci_api_key.pem | openssl md5 -c

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt "echo vm-standard2-1-ad1-0001 > expected" 
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
 	-scp -F ssh-config opc@mgmt:expected .
-	-sleep 5  # Make sure that the filesystem has synchronised
+	-sleep 10  # Make sure that the filesystem has synchronised
+	-ls
 	-scp -F ssh-config opc@mgmt:slurm-2.out .
 	cd oci-cluster-terraform \
 	  && ../terraform destroy -auto-approve

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ azure-test.pub:
 	ssh-keygen -N ""  -f azure-test
 
 $(TF_VARS): azure-test.pub
+	cat oci_api_key.pem
 	git clone https://github.com/ACRC/oci-cluster-terraform.git
 	cp $(TF_VARS).example $(TF_VARS)
 	sed -i -e '/private_key_path/ s/\/home\/user\/.oci/../' $(TF_VARS)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(TF_VARS): azure-test.pub
 	  && ../terraform plan \
 	  && ../terraform apply -auto-approve
 	# we need to ignore errors between here and the destroy, so make commands start with a minus
-	-echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking no\n\tCheckHostIP no\n\tHostname " > ssh-config
+	-echo -n "Host mgmt\n\tIdentityFile azure-test\n\tHostname " > ssh-config
 	-terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' >> ssh-config
 	-cat ssh-config
 	-mkdir --mode=700 ~/.ssh

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(TF_VARS): azure-test.pub
 	  && ../terraform plan \
 	  && ../terraform apply -auto-approve
 	# we need to ignore errors between here and the destroy, so make commands start with a minus
-	-echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking no\n\tCheckHostIP no\n\tHostname " > ssh-config
+	-echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking yes\n\tCheckHostIP no\n\tHostname " > ssh-config
 	-terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' >> ssh-config
 	-cat ssh-config
 	-ssh -F ssh-config opc@mgmt  "while [ ! -f /mnt/shared/finalised/mgmt ] ; do sleep 2; done" ## wait for ansible

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,6 @@ azure-test.pub:
 	ssh-keygen -N ""  -f azure-test
 
 $(TF_VARS): azure-test.pub
-	echo ${MY_MAPPED_ENV_VAR}
-	echo ${MY_MAPPED_ENV_VAR} | base64 --decode > oci_api_key.pem
-	ls -l
-	cat oci_api_key.pem
-	openssl rsa -pubout -outform DER -in oci_api_key.pem | openssl md5 -c
 	git clone https://github.com/ACRC/oci-cluster-terraform.git
 	cp $(TF_VARS).example $(TF_VARS)
 	sed -i -e '/private_key_path/ s/\/home\/user\/.oci/../' $(TF_VARS)

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt  "echo -ne 'VM.Standard2.1:\n  1: 1\n  2: 1\n  3: 1\n' > limits.yaml && ./finish"
 	-ssh -F ssh-config opc@mgmt  "sudo mkdir -p /mnt/shared/test && sudo chown opc /mnt/shared/test"
 	-ssh -F ssh-config opc@mgmt  'echo -ne "#!/bin/bash\n\nsrun hostname\n" > test.slm'
-	-ssh -F ssh-config opc@mgmt "sacct -j 2 --format=NodeList --noheader | tr -d '[:space:]' > expected"  # Get the node the job ran on
-	-ssh -F ssh-config opc@mgmt "echo >> expected"  # Add newline to end
+	-ssh -F ssh-config opc@mgmt "sacct -j 2 --format=NodeList --noheader | tr -d ' ' > expected"  # Get the node the job ran on
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
 	-sleep 5  # Make sure that the filesystem has synchronised
 	-scp -F ssh-config opc@mgmt:expected .

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ $(TF_VARS): azure-test.pub
 	-ssh -F ssh-config opc@mgmt "echo vm-standard2-1-ad1-0001 > expected" 
 	-ssh -F ssh-config opc@mgmt  "sbatch --chdir=/mnt/shared/test --wait test.slm"
 	-scp -F ssh-config opc@mgmt:expected .
+	-sleep 5  # Make sure that the filesystem has synchronised
 	-scp -F ssh-config opc@mgmt:slurm-2.out .
 	cd oci-cluster-terraform \
 	  && ../terraform destroy -auto-approve

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(TF_VARS): azure-test.pub
 	  && ../terraform plan \
 	  && ../terraform apply -auto-approve
 	# we need to ignore errors between here and the destroy, so make commands start with a minus
-	echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking no\n\tHostname " > ssh-config
+	echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking no\n\tCheckHostIP no\n\tHostname " > ssh-config
 	terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' >> ssh-config
 	-cat ssh-config
 	-ssh -F ssh-config opc@mgmt  "while [ ! -f /mnt/shared/finalised/mgmt ] ; do sleep 2; done" ## wait for ansible

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ $(TF_VARS): azure-test.pub
 	-echo -n "Host mgmt\n\tIdentityFile azure-test\n\tStrictHostKeyChecking no\n\tCheckHostIP no\n\tHostname " > ssh-config
 	-terraform show -no-color oci-cluster-terraform/terraform.tfstate | grep 'PublicIP' | awk '{print $$3}' >> ssh-config
 	-cat ssh-config
+	-ls -l
+	-ls -l ~/.ssh
 	-ssh -F ssh-config opc@mgmt  "while [ ! -f /mnt/shared/finalised/mgmt ] ; do sleep 2; done" ## wait for ansible
 	-ssh -F ssh-config opc@mgmt  "echo -ne 'VM.Standard2.1:\n  1: 1\n  2: 1\n  3: 1\n' > limits.yaml && ./finish"
 	-ssh -F ssh-config opc@mgmt  "sudo mkdir -p /mnt/shared/test && sudo chown opc /mnt/shared/test"

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Your key file needs to be `base64` encoded in to a single long string, e.g.
 $ cat /home/username/.oci/oci_test_key.pem | base64 --wrap=0
 ```
 
-Add this as the variable `private_key` and mark the variable as a secret (click the :lock: icon).
+Add this as the variable `oci_api_key.pem` and mark the variable as a secret (click the :lock: icon).
 
 You will also need to set
 
 ```
-tenancy_ocid
-user_ocid
-fingerprint
-compartment_ocid
+TENANCY_OCID
+USER_OCID
+FINGERPRINT
+COMPARTMENT_OCID
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,6 @@ steps:
 
 - script: |
     echo ${MY_MAPPED_ENV_VAR} | base64 --decode > oci_api_key.pem
-    echo ${MY_MAPPED_ENV_VAR}
     make
   displayName: 'Run Makefile'
   env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ steps:
   displayName: 'Run a one-line script'
 
 - script: |
+    echo ${MY_MAPPED_ENV_VAR} | base64 --decode > oci_api_key.pem
     make
   displayName: 'Run Makefile'
   env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ steps:
   displayName: 'Run a one-line script'
 
 - script: |
-    echo ${MY_MAPPED_ENV_VAR} > oci_api_key.pem
+    echo ${MY_MAPPED_ENV_VAR} | base64 --decode > oci_api_key.pem
     echo ${MY_MAPPED_ENV_VAR}
     make
   displayName: 'Run Makefile'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ steps:
 
 - script: |
     echo ${MY_MAPPED_ENV_VAR} > oci_api_key.pem
+    echo ${MY_MAPPED_ENV_VAR}
     make
   displayName: 'Run Makefile'
   env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ steps:
   displayName: 'Run a one-line script'
 
 - script: |
-    echo ${MY_MAPPED_ENV_VAR} | base64 --decode > oci_api_key.pem
+    echo ${MY_MAPPED_ENV_VAR} > oci_api_key.pem
     make
   displayName: 'Run Makefile'
   env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,6 @@ steps:
   displayName: 'Run a one-line script'
 
 - script: |
-    echo ${MY_MAPPED_ENV_VAR} | base64 --decode > oci_api_key.pem
     make
   displayName: 'Run Makefile'
   env:


### PR DESCRIPTION
The main change I made here to get past the problem we were having is to write the management node IP directly into the SSH config file rather than going via a variable.

Other tweaks are:

- Use the locally downloaded terraform
- Get the real hostname of the node the test job ran on
- Download the test output and compare locally, after the destroy to allow for it to fail